### PR TITLE
Initialize ECM repository skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# .NET build artifacts
+bin/
+obj/
+
+# Visual Studio / VS Code
+.vscode/
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Logs
+*.log
+
+# Python
+__pycache__/
+*.py[cod]
+.env
+.venv/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # ECM
+
+Bộ khởi tạo cho hệ thống ECM (Enterprise Content Management) được chia thành nhiều service nhỏ theo kiến trúc trong `ARCHITECT.md`. Kho repo hiện chỉ chứa các skeleton để bắt đầu phát triển; chưa có phần cài đặt nghiệp vụ hay gói phụ thuộc cụ thể.
+
+## Thư mục chính
+
+```
+/host/AppHost           # Điểm khởi chạy Aspire (placeholder)
+/libs/ServiceDefaults   # Cấu hình chia sẻ cho mọi service .NET
+/apps                   # Tập hợp các ứng dụng và worker
+  ├── ecm               # API gateway/edge
+  ├── document-services # CRUD tài liệu + outbox
+  ├── file-services     # Presign MinIO
+  ├── workflow          # Quản lý workflow
+  ├── search-api        # API tra cứu
+  ├── search-indexer    # Worker build search index
+  ├── outbox-dispatcher # Worker phát sự kiện
+  ├── notify            # Worker gửi thông báo
+  ├── audit             # Worker lưu vết
+  ├── retention         # Worker thực thi chính sách lưu trữ
+  └── ocr               # Service Python cho OCR
+/docker                 # Tập tin phục vụ khởi tạo hạ tầng DEV
+```
+
+## Bắt đầu phát triển
+
+1. Cài .NET 8 SDK và Python 3.11 trở lên.
+2. Tạo solution và thêm các project theo nhu cầu (`dotnet new sln && dotnet sln add ...`).
+3. Bổ sung gói NuGet/AspNetCore, thư viện Aspire khi cần.
+4. Đối với OCR, tạo virtualenv và cài đặt `pip install -e .` trong `apps/ocr`.
+5. Cập nhật `docker/compose.yml` để mô phỏng hạ tầng Postgres, MinIO, Redpanda theo kiến trúc.
+
+Các file mã nguồn hiện chủ yếu nhằm mô tả contract, giữ cho dự án biên dịch được khi bổ sung SDK tương ứng.

--- a/apps/audit/Audit.csproj
+++ b/apps/audit/Audit.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
+  </ItemGroup>
+</Project>

--- a/apps/audit/Program.cs
+++ b/apps/audit/Program.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Hosting;
+using ServiceDefaults;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddDefaultConfiguration()
+       .AddServiceDefaults();
+
+builder.Services.AddHostedService<AuditWorker>();
+
+await builder.Build().RunAsync();
+
+class AuditWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // TODO: Append audit events to durable storage.
+            await Task.Delay(TimeSpan.FromSeconds(45), stoppingToken);
+        }
+    }
+}

--- a/apps/document-services/DocumentServices.csproj
+++ b/apps/document-services/DocumentServices.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
+  </ItemGroup>
+</Project>

--- a/apps/document-services/Program.cs
+++ b/apps/document-services/Program.cs
@@ -1,0 +1,23 @@
+using ServiceDefaults;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddDefaultConfiguration()
+       .AddServiceDefaults();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapGet("/api/documents", () => Results.Ok(Array.Empty<object>()))
+   .WithName("ListDocuments")
+   .WithDescription("List all documents available to the caller.");
+
+app.Run();

--- a/apps/ecm/Ecm.csproj
+++ b/apps/ecm/Ecm.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
+  </ItemGroup>
+</Project>

--- a/apps/ecm/Program.cs
+++ b/apps/ecm/Program.cs
@@ -1,0 +1,15 @@
+using ServiceDefaults;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddDefaultConfiguration()
+       .AddServiceDefaults();
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapGet("/health", () => Results.Ok(new { status = "healthy" }));
+app.MapControllers();
+
+app.Run();

--- a/apps/file-services/FileServices.csproj
+++ b/apps/file-services/FileServices.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
+  </ItemGroup>
+</Project>

--- a/apps/file-services/Program.cs
+++ b/apps/file-services/Program.cs
@@ -1,0 +1,14 @@
+using ServiceDefaults;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddDefaultConfiguration()
+       .AddServiceDefaults();
+
+var app = builder.Build();
+
+app.MapGet("/api/files/presign", () => Results.Ok(new { url = "https://minio.local/presigned" }))
+   .WithName("GeneratePresignedUrl")
+   .WithDescription("Return a placeholder presigned URL for uploads.");
+
+app.Run();

--- a/apps/notify/Notify.csproj
+++ b/apps/notify/Notify.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
+  </ItemGroup>
+</Project>

--- a/apps/notify/Program.cs
+++ b/apps/notify/Program.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Hosting;
+using ServiceDefaults;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddDefaultConfiguration()
+       .AddServiceDefaults();
+
+builder.Services.AddHostedService<NotificationWorker>();
+
+await builder.Build().RunAsync();
+
+class NotificationWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // TODO: Deliver email/webhook notifications.
+            await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+        }
+    }
+}

--- a/apps/ocr/pyproject.toml
+++ b/apps/ocr/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "ecm-ocr"
+version = "0.1.0"
+description = "OCR microservice placeholder for ECM"
+authors = [{ name = "ECM Team" }]
+dependencies = [
+    "fastapi",
+    "uvicorn",
+]
+requires-python = ">=3.11"
+
+[tool.uvicorn]
+factory = false

--- a/apps/ocr/src/ocr/__init__.py
+++ b/apps/ocr/src/ocr/__init__.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="ECM OCR Service", version="0.1.0")
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Return a simple readiness status."""
+    return {"status": "ok"}
+
+
+@app.post("/api/ocr/extract")
+async def extract_text() -> dict[str, list[str]]:
+    """Placeholder OCR extraction endpoint."""
+    # TODO: Integrate Tesseract or PaddleOCR pipeline.
+    return {"tokens": []}

--- a/apps/outbox-dispatcher/OutboxDispatcher.csproj
+++ b/apps/outbox-dispatcher/OutboxDispatcher.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
+  </ItemGroup>
+</Project>

--- a/apps/outbox-dispatcher/Program.cs
+++ b/apps/outbox-dispatcher/Program.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Hosting;
+using ServiceDefaults;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddDefaultConfiguration()
+       .AddServiceDefaults();
+
+builder.Services.AddHostedService<OutboxDispatcherWorker>();
+
+await builder.Build().RunAsync();
+
+class OutboxDispatcherWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // TODO: Poll the outbox table and publish events to Redpanda.
+            await Task.Delay(TimeSpan.FromSeconds(15), stoppingToken);
+        }
+    }
+}

--- a/apps/retention/Program.cs
+++ b/apps/retention/Program.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Hosting;
+using ServiceDefaults;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddDefaultConfiguration()
+       .AddServiceDefaults();
+
+builder.Services.AddHostedService<RetentionWorker>();
+
+await builder.Build().RunAsync();
+
+class RetentionWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // TODO: Evaluate retention policies and purge expired content.
+            await Task.Delay(TimeSpan.FromHours(1), stoppingToken);
+        }
+    }
+}

--- a/apps/retention/Retention.csproj
+++ b/apps/retention/Retention.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
+  </ItemGroup>
+</Project>

--- a/apps/search-api/Program.cs
+++ b/apps/search-api/Program.cs
@@ -1,0 +1,14 @@
+using ServiceDefaults;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddDefaultConfiguration()
+       .AddServiceDefaults();
+
+var app = builder.Build();
+
+app.MapGet("/api/search", (string? q) => Results.Ok(new { query = q ?? string.Empty, results = Array.Empty<object>() }))
+   .WithName("SearchDocuments")
+   .WithDescription("Execute a placeholder hybrid search query.");
+
+app.Run();

--- a/apps/search-api/SearchApi.csproj
+++ b/apps/search-api/SearchApi.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
+  </ItemGroup>
+</Project>

--- a/apps/search-indexer/Program.cs
+++ b/apps/search-indexer/Program.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Hosting;
+using ServiceDefaults;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddDefaultConfiguration()
+       .AddServiceDefaults();
+
+builder.Services.AddHostedService<SearchIndexerWorker>();
+
+await builder.Build().RunAsync();
+
+class SearchIndexerWorker : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // TODO: Consume events and build search indexes.
+            await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
+        }
+    }
+}

--- a/apps/search-indexer/SearchIndexer.csproj
+++ b/apps/search-indexer/SearchIndexer.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
+  </ItemGroup>
+</Project>

--- a/apps/workflow/Program.cs
+++ b/apps/workflow/Program.cs
@@ -1,0 +1,14 @@
+using ServiceDefaults;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddDefaultConfiguration()
+       .AddServiceDefaults();
+
+var app = builder.Build();
+
+app.MapGet("/api/workflows", () => Results.Ok(Array.Empty<object>()))
+   .WithName("ListWorkflowDefinitions")
+   .WithDescription("List available workflow definitions.");
+
+app.Run();

--- a/apps/workflow/Workflow.csproj
+++ b/apps/workflow/Workflow.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
+  </ItemGroup>
+</Project>

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,50 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: ecm
+      POSTGRES_PASSWORD: ecm
+      POSTGRES_DB: ecm
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./init/db-init.sql:/docker-entrypoint-initdb.d/10-init.sql:ro
+
+  minio:
+    image: minio/minio:RELEASE.2024-03-30T00-00-00Z
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: miniominio
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+      - ./init/mc-init.sh:/docker-entrypoint.d/mc-init.sh:ro
+
+  redpanda:
+    image: redpandadata/redpanda:v23.3.11
+    command:
+      - redpanda
+      - start
+      - --overprovisioned
+      - --smp
+      - "1"
+      - --reserve-memory
+      - 0M
+      - --node-id
+      - "0"
+      - --check=false
+    ports:
+      - "9092:9092"
+      - "9644:9644"
+    volumes:
+      - ./init/topics-init.sh:/docker-entrypoint.d/topics-init.sh:ro
+
+volumes:
+  pgdata:
+  minio-data:

--- a/docker/init/db-init.sql
+++ b/docker/init/db-init.sql
@@ -1,0 +1,2 @@
+-- Placeholder for database initialization script.
+-- TODO: Create schemas (document, workflow, ocr, search, audit) and enable required extensions.

--- a/docker/init/mc-init.sh
+++ b/docker/init/mc-init.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -euo pipefail
+
+# Placeholder script for MinIO bucket initialization.
+# Use `mc alias set` and `mc mb` once the MinIO client is available in the image.

--- a/docker/init/topics-init.sh
+++ b/docker/init/topics-init.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -euo pipefail
+
+# Placeholder script for Redpanda topic creation.
+# Example: rpk topic create document.events ocr.events

--- a/host/AppHost/AppHost.csproj
+++ b/host/AppHost/AppHost.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
+    <ProjectReference Include="../../apps/document-services/DocumentServices.csproj" />
+    <ProjectReference Include="../../apps/search-indexer/SearchIndexer.csproj" />
+    <ProjectReference Include="../../apps/outbox-dispatcher/OutboxDispatcher.csproj" />
+  </ItemGroup>
+</Project>

--- a/host/AppHost/Program.cs
+++ b/host/AppHost/Program.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// TODO: Replace with .NET Aspire DistributedApplication configuration when Aspire packages are added.
+// The placeholders below document the intended wiring between projects.
+var host = builder.Build();
+
+Console.WriteLine("AppHost placeholder ready. Configure DistributedApplication here.");
+
+host.Run();

--- a/libs/ServiceDefaults/ServiceDefaults.csproj
+++ b/libs/ServiceDefaults/ServiceDefaults.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/libs/ServiceDefaults/ServiceDefaultsExtensions.cs
+++ b/libs/ServiceDefaults/ServiceDefaultsExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace ServiceDefaults;
+
+public static class ServiceDefaultsExtensions
+{
+    public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
+    {
+        // Register common observability, health checks, and resilience policies here.
+        builder.Services.AddHealthChecks();
+        return builder;
+    }
+
+    public static IHostApplicationBuilder AddDefaultConfiguration(this IHostApplicationBuilder builder)
+    {
+        builder.Configuration.AddEnvironmentVariables(prefix: "ECM_");
+        return builder;
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold host AppHost project, shared ServiceDefaults library, and service/worker stubs aligned with the proposed architecture
- add placeholder Python OCR package and docker initialization assets for infrastructure dependencies
- document the repository layout in the README and add a base .gitignore

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e62e05e4c88328b8e915ce9917e147