### PR TITLE
Add Aspire orchestration and shared test scaffolding

### DIFF
--- a/ARCHITECT.md
+++ b/ARCHITECT.md
@@ -67,8 +67,15 @@ var minio = builder.AddConnectionString("minio");
 var document = builder.AddProject<Projects.DocumentServices>("document-services")
     .WithReference(pg).WithReference(kafka).WithReference(minio);
 
+builder.AddProject<Projects.Ecm>("ecm").WithReference(pg).WithReference(kafka);
+builder.AddProject<Projects.FileServices>("file-services").WithReference(minio).WithReference(pg);
+builder.AddProject<Projects.Workflow>("workflow").WithReference(pg).WithReference(kafka);
+builder.AddProject<Projects.SearchApi>("search-api").WithReference(pg).WithReference(kafka);
 builder.AddProject<Projects.SearchIndexer>("search-indexer").WithReference(pg).WithReference(kafka);
 builder.AddProject<Projects.OutboxDispatcher>("outbox-dispatcher").WithReference(pg).WithReference(kafka);
+builder.AddProject<Projects.Notify>("notify").WithReference(kafka);
+builder.AddProject<Projects.Audit>("audit").WithReference(pg).WithReference(kafka);
+builder.AddProject<Projects.Retention>("retention").WithReference(pg).WithReference(kafka);
 
 builder.Build().Run();
 ```

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,16 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.0.0" />
+    <PackageVersion Include="Aspire.ServiceDefaults" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.0.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
+    <PackageVersion Include="xunit" Version="2.5.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+</Project>

--- a/ECM.sln
+++ b/ECM.sln
@@ -1,0 +1,100 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6F7B4D52-3B15-4A79-9BB3-E8B54915A43C}"
+ProjectSection(SolutionItems) = preProject
+ARCHITECT.md = ARCHITECT.md
+README.md = README.md
+Directory.Packages.props = Directory.Packages.props
+EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppHost", "host\\AppHost\\AppHost.csproj", "{56D5ECF6-25EB-4DD9-8EC7-601F8A14258B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceDefaults", "libs\\ServiceDefaults\\ServiceDefaults.csproj", "{505CAA70-78FC-4746-8C40-B6EB1AB8F5F7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ecm", "apps\\ecm\\Ecm.csproj", "{2879C29D-7276-464A-B841-53ABD4F4C294}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocumentServices", "apps\\document-services\\DocumentServices.csproj", "{FE7228FE-6FE5-4A4C-9E0A-A98BC9388615}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileServices", "apps\\file-services\\FileServices.csproj", "{D8BE03CD-12EE-497E-8840-CD2FCA473050}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Workflow", "apps\\workflow\\Workflow.csproj", "{7D88D2C0-90E6-4DBB-86D1-CA7D1F33B7EF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchApi", "apps\\search-api\\SearchApi.csproj", "{8FB5D16F-4A05-4A83-997E-5C999BABE84E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SearchIndexer", "apps\\search-indexer\\SearchIndexer.csproj", "{FA18F88D-0695-47DC-8C79-B9946CA6222A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OutboxDispatcher", "apps\\outbox-dispatcher\\OutboxDispatcher.csproj", "{565B30EA-E91F-451B-B101-73D21E6ABA24}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Notify", "apps\\notify\\Notify.csproj", "{9882E492-235A-42A3-8A64-F1077BC3A286}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Audit", "apps\\audit\\Audit.csproj", "{5AEB7F9E-61A2-4288-BA23-5AD310F2EA0C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Retention", "apps\\retention\\Retention.csproj", "{EB004120-4BB0-40FE-9EC9-E643E3BEDF37}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceDefaults.Tests", "tests\\ServiceDefaults.Tests\\ServiceDefaults.Tests.csproj", "{211451B8-E711-4A6A-8A16-696984F1F651}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{56D5ECF6-25EB-4DD9-8EC7-601F8A14258B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{56D5ECF6-25EB-4DD9-8EC7-601F8A14258B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{56D5ECF6-25EB-4DD9-8EC7-601F8A14258B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{56D5ECF6-25EB-4DD9-8EC7-601F8A14258B}.Release|Any CPU.Build.0 = Release|Any CPU
+{505CAA70-78FC-4746-8C40-B6EB1AB8F5F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{505CAA70-78FC-4746-8C40-B6EB1AB8F5F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{505CAA70-78FC-4746-8C40-B6EB1AB8F5F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{505CAA70-78FC-4746-8C40-B6EB1AB8F5F7}.Release|Any CPU.Build.0 = Release|Any CPU
+{2879C29D-7276-464A-B841-53ABD4F4C294}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{2879C29D-7276-464A-B841-53ABD4F4C294}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{2879C29D-7276-464A-B841-53ABD4F4C294}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{2879C29D-7276-464A-B841-53ABD4F4C294}.Release|Any CPU.Build.0 = Release|Any CPU
+{FE7228FE-6FE5-4A4C-9E0A-A98BC9388615}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{FE7228FE-6FE5-4A4C-9E0A-A98BC9388615}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{FE7228FE-6FE5-4A4C-9E0A-A98BC9388615}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{FE7228FE-6FE5-4A4C-9E0A-A98BC9388615}.Release|Any CPU.Build.0 = Release|Any CPU
+{D8BE03CD-12EE-497E-8840-CD2FCA473050}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{D8BE03CD-12EE-497E-8840-CD2FCA473050}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{D8BE03CD-12EE-497E-8840-CD2FCA473050}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{D8BE03CD-12EE-497E-8840-CD2FCA473050}.Release|Any CPU.Build.0 = Release|Any CPU
+{7D88D2C0-90E6-4DBB-86D1-CA7D1F33B7EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{7D88D2C0-90E6-4DBB-86D1-CA7D1F33B7EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{7D88D2C0-90E6-4DBB-86D1-CA7D1F33B7EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{7D88D2C0-90E6-4DBB-86D1-CA7D1F33B7EF}.Release|Any CPU.Build.0 = Release|Any CPU
+{8FB5D16F-4A05-4A83-997E-5C999BABE84E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{8FB5D16F-4A05-4A83-997E-5C999BABE84E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{8FB5D16F-4A05-4A83-997E-5C999BABE84E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{8FB5D16F-4A05-4A83-997E-5C999BABE84E}.Release|Any CPU.Build.0 = Release|Any CPU
+{FA18F88D-0695-47DC-8C79-B9946CA6222A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{FA18F88D-0695-47DC-8C79-B9946CA6222A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{FA18F88D-0695-47DC-8C79-B9946CA6222A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{FA18F88D-0695-47DC-8C79-B9946CA6222A}.Release|Any CPU.Build.0 = Release|Any CPU
+{565B30EA-E91F-451B-B101-73D21E6ABA24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{565B30EA-E91F-451B-B101-73D21E6ABA24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{565B30EA-E91F-451B-B101-73D21E6ABA24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{565B30EA-E91F-451B-B101-73D21E6ABA24}.Release|Any CPU.Build.0 = Release|Any CPU
+{9882E492-235A-42A3-8A64-F1077BC3A286}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{9882E492-235A-42A3-8A64-F1077BC3A286}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{9882E492-235A-42A3-8A64-F1077BC3A286}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{9882E492-235A-42A3-8A64-F1077BC3A286}.Release|Any CPU.Build.0 = Release|Any CPU
+{5AEB7F9E-61A2-4288-BA23-5AD310F2EA0C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{5AEB7F9E-61A2-4288-BA23-5AD310F2EA0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{5AEB7F9E-61A2-4288-BA23-5AD310F2EA0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{5AEB7F9E-61A2-4288-BA23-5AD310F2EA0C}.Release|Any CPU.Build.0 = Release|Any CPU
+{EB004120-4BB0-40FE-9EC9-E643E3BEDF37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{EB004120-4BB0-40FE-9EC9-E643E3BEDF37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{EB004120-4BB0-40FE-9EC9-E643E3BEDF37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{EB004120-4BB0-40FE-9EC9-E643E3BEDF37}.Release|Any CPU.Build.0 = Release|Any CPU
+{211451B8-E711-4A6A-8A16-696984F1F651}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{211451B8-E711-4A6A-8A16-696984F1F651}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{211451B8-E711-4A6A-8A16-696984F1F651}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{211451B8-E711-4A6A-8A16-696984F1F651}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Bộ khởi tạo cho hệ thống ECM (Enterprise Content Management) được 
 ## Thư mục chính
 
 ```
-/host/AppHost           # Điểm khởi chạy Aspire (placeholder)
+/ECM.sln                # Solution gộp tất cả project .NET
+/host/AppHost           # Điểm khởi chạy Aspire (DistributedApplication)
 /libs/ServiceDefaults   # Cấu hình chia sẻ cho mọi service .NET
 /apps                   # Tập hợp các ứng dụng và worker
   ├── ecm               # API gateway/edge
@@ -19,15 +20,19 @@ Bộ khởi tạo cho hệ thống ECM (Enterprise Content Management) được 
   ├── audit             # Worker lưu vết
   ├── retention         # Worker thực thi chính sách lưu trữ
   └── ocr               # Service Python cho OCR
+/tests                  # Test project (xUnit) cho shared libraries
 /docker                 # Tập tin phục vụ khởi tạo hạ tầng DEV
 ```
 
 ## Bắt đầu phát triển
 
 1. Cài .NET 8 SDK và Python 3.11 trở lên.
-2. Tạo solution và thêm các project theo nhu cầu (`dotnet new sln && dotnet sln add ...`).
-3. Bổ sung gói NuGet/AspNetCore, thư viện Aspire khi cần.
-4. Đối với OCR, tạo virtualenv và cài đặt `pip install -e .` trong `apps/ocr`.
-5. Cập nhật `docker/compose.yml` để mô phỏng hạ tầng Postgres, MinIO, Redpanda theo kiến trúc.
+2. Mở solution `ECM.sln` hoặc chạy build trực tiếp với `dotnet build ECM.sln`.
+3. Chạy Aspire AppHost: `dotnet run --project host/AppHost`.
+4. Chạy test: `dotnet test ECM.sln` để xác nhận các cấu hình chung hoạt động.
+5. Đối với OCR, tạo virtualenv và cài đặt `pip install -e .` trong `apps/ocr`.
+6. Cập nhật `docker/compose.yml` để mô phỏng hạ tầng Postgres, MinIO, Redpanda theo kiến trúc.
+
+> **Vì sao trước đây không có `.sln`?** Skeleton ban đầu bỏ trống solution để người dùng linh hoạt sắp xếp project. Phiên bản này đã cung cấp sẵn `ECM.sln` gom toàn bộ AppHost, thư viện và test nhằm đồng bộ với cấu trúc kiến trúc mô tả trong `ARCHITECT.md`.
 
 Các file mã nguồn hiện chủ yếu nhằm mô tả contract, giữ cho dự án biên dịch được khi bổ sung SDK tương ứng.

--- a/apps/audit/Program.cs
+++ b/apps/audit/Program.cs
@@ -3,8 +3,7 @@ using ServiceDefaults;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.AddDefaultConfiguration()
-       .AddServiceDefaults();
+builder.AddServiceDefaults();
 
 builder.Services.AddHostedService<AuditWorker>();
 

--- a/apps/document-services/Program.cs
+++ b/apps/document-services/Program.cs
@@ -2,8 +2,7 @@ using ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddDefaultConfiguration()
-       .AddServiceDefaults();
+builder.AddServiceDefaults();
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -16,6 +15,7 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+app.MapDefaultEndpoints();
 app.MapGet("/api/documents", () => Results.Ok(Array.Empty<object>()))
    .WithName("ListDocuments")
    .WithDescription("List all documents available to the caller.");

--- a/apps/ecm/Program.cs
+++ b/apps/ecm/Program.cs
@@ -2,14 +2,13 @@ using ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddDefaultConfiguration()
-       .AddServiceDefaults();
+builder.AddServiceDefaults();
 
 builder.Services.AddControllers();
 
 var app = builder.Build();
 
-app.MapGet("/health", () => Results.Ok(new { status = "healthy" }));
+app.MapDefaultEndpoints();
 app.MapControllers();
 
 app.Run();

--- a/apps/file-services/Program.cs
+++ b/apps/file-services/Program.cs
@@ -2,11 +2,11 @@ using ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddDefaultConfiguration()
-       .AddServiceDefaults();
+builder.AddServiceDefaults();
 
 var app = builder.Build();
 
+app.MapDefaultEndpoints();
 app.MapGet("/api/files/presign", () => Results.Ok(new { url = "https://minio.local/presigned" }))
    .WithName("GeneratePresignedUrl")
    .WithDescription("Return a placeholder presigned URL for uploads.");

--- a/apps/notify/Program.cs
+++ b/apps/notify/Program.cs
@@ -3,8 +3,7 @@ using ServiceDefaults;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.AddDefaultConfiguration()
-       .AddServiceDefaults();
+builder.AddServiceDefaults();
 
 builder.Services.AddHostedService<NotificationWorker>();
 

--- a/apps/outbox-dispatcher/Program.cs
+++ b/apps/outbox-dispatcher/Program.cs
@@ -3,8 +3,7 @@ using ServiceDefaults;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.AddDefaultConfiguration()
-       .AddServiceDefaults();
+builder.AddServiceDefaults();
 
 builder.Services.AddHostedService<OutboxDispatcherWorker>();
 

--- a/apps/retention/Program.cs
+++ b/apps/retention/Program.cs
@@ -3,8 +3,7 @@ using ServiceDefaults;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.AddDefaultConfiguration()
-       .AddServiceDefaults();
+builder.AddServiceDefaults();
 
 builder.Services.AddHostedService<RetentionWorker>();
 

--- a/apps/search-api/Program.cs
+++ b/apps/search-api/Program.cs
@@ -2,11 +2,11 @@ using ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddDefaultConfiguration()
-       .AddServiceDefaults();
+builder.AddServiceDefaults();
 
 var app = builder.Build();
 
+app.MapDefaultEndpoints();
 app.MapGet("/api/search", (string? q) => Results.Ok(new { query = q ?? string.Empty, results = Array.Empty<object>() }))
    .WithName("SearchDocuments")
    .WithDescription("Execute a placeholder hybrid search query.");

--- a/apps/search-indexer/Program.cs
+++ b/apps/search-indexer/Program.cs
@@ -3,8 +3,7 @@ using ServiceDefaults;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.AddDefaultConfiguration()
-       .AddServiceDefaults();
+builder.AddServiceDefaults();
 
 builder.Services.AddHostedService<SearchIndexerWorker>();
 

--- a/apps/workflow/Program.cs
+++ b/apps/workflow/Program.cs
@@ -2,11 +2,11 @@ using ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.AddDefaultConfiguration()
-       .AddServiceDefaults();
+builder.AddServiceDefaults();
 
 var app = builder.Build();
 
+app.MapDefaultEndpoints();
 app.MapGet("/api/workflows", () => Results.Ok(Array.Empty<object>()))
    .WithName("ListWorkflowDefinitions")
    .WithDescription("List available workflow definitions.");

--- a/host/AppHost/AppHost.csproj
+++ b/host/AppHost/AppHost.csproj
@@ -6,9 +6,19 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
+    <ProjectReference Include="../../apps/ecm/Ecm.csproj" />
     <ProjectReference Include="../../apps/document-services/DocumentServices.csproj" />
+    <ProjectReference Include="../../apps/file-services/FileServices.csproj" />
+    <ProjectReference Include="../../apps/workflow/Workflow.csproj" />
+    <ProjectReference Include="../../apps/search-api/SearchApi.csproj" />
     <ProjectReference Include="../../apps/search-indexer/SearchIndexer.csproj" />
     <ProjectReference Include="../../apps/outbox-dispatcher/OutboxDispatcher.csproj" />
+    <ProjectReference Include="../../apps/notify/Notify.csproj" />
+    <ProjectReference Include="../../apps/audit/Audit.csproj" />
+    <ProjectReference Include="../../apps/retention/Retention.csproj" />
   </ItemGroup>
 </Project>

--- a/host/AppHost/Program.cs
+++ b/host/AppHost/Program.cs
@@ -1,11 +1,49 @@
-using Microsoft.Extensions.Hosting;
+using Aspire.Hosting;
 
-var builder = Host.CreateApplicationBuilder(args);
+var builder = DistributedApplication.CreateBuilder(args);
 
-// TODO: Replace with .NET Aspire DistributedApplication configuration when Aspire packages are added.
-// The placeholders below document the intended wiring between projects.
-var host = builder.Build();
+var postgres = builder.AddConnectionString("postgres");
+var kafka = builder.AddConnectionString("kafka");
+var minio = builder.AddConnectionString("minio");
 
-Console.WriteLine("AppHost placeholder ready. Configure DistributedApplication here.");
+builder.AddProject<Projects.Ecm>("ecm")
+    .WithReference(postgres)
+    .WithReference(kafka);
 
-host.Run();
+builder.AddProject<Projects.DocumentServices>("document-services")
+    .WithReference(postgres)
+    .WithReference(kafka)
+    .WithReference(minio);
+
+builder.AddProject<Projects.FileServices>("file-services")
+    .WithReference(minio)
+    .WithReference(postgres);
+
+builder.AddProject<Projects.Workflow>("workflow")
+    .WithReference(postgres)
+    .WithReference(kafka);
+
+builder.AddProject<Projects.SearchApi>("search-api")
+    .WithReference(postgres)
+    .WithReference(kafka);
+
+builder.AddProject<Projects.SearchIndexer>("search-indexer")
+    .WithReference(postgres)
+    .WithReference(kafka);
+
+builder.AddProject<Projects.OutboxDispatcher>("outbox-dispatcher")
+    .WithReference(postgres)
+    .WithReference(kafka);
+
+builder.AddProject<Projects.Notify>("notify")
+    .WithReference(kafka);
+
+builder.AddProject<Projects.Audit>("audit")
+    .WithReference(postgres)
+    .WithReference(kafka);
+
+builder.AddProject<Projects.Retention>("retention")
+    .WithReference(postgres)
+    .WithReference(kafka);
+
+builder.Build().Run();

--- a/libs/ServiceDefaults/ServiceDefaults.csproj
+++ b/libs/ServiceDefaults/ServiceDefaults.csproj
@@ -4,4 +4,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Aspire.ServiceDefaults" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+  </ItemGroup>
 </Project>

--- a/libs/ServiceDefaults/ServiceDefaultsExtensions.cs
+++ b/libs/ServiceDefaults/ServiceDefaultsExtensions.cs
@@ -1,6 +1,12 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Http.Resilience;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 
 namespace ServiceDefaults;
 
@@ -8,14 +14,36 @@ public static class ServiceDefaultsExtensions
 {
     public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
     {
-        // Register common observability, health checks, and resilience policies here.
-        builder.Services.AddHealthChecks();
+        builder.AddDefaultConfiguration();
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddHttpClient();
+        builder.Services.AddServiceDiscovery();
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            http.AddStandardResilienceHandler();
+            http.AddServiceDiscovery();
+        });
+
+        builder.Services.AddOpenTelemetry()
+            .ConfigureResource(resource => resource.AddService(builder.Environment.ApplicationName))
+            .WithMetrics(metrics => metrics.AddMeter("Microsoft.AspNetCore.Hosting").AddMeter("System.Net.Http"))
+            .WithTracing(tracing => tracing.AddSource("System.Net.Http.HttpClient"))
+            .UseOtlpExporter()
+            .UseConsoleExporter();
+
         return builder;
     }
 
     public static IHostApplicationBuilder AddDefaultConfiguration(this IHostApplicationBuilder builder)
     {
         builder.Configuration.AddEnvironmentVariables(prefix: "ECM_");
+        return builder;
+    }
+
+    public static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddHealthChecks().AddCheck("self", () => HealthCheckResult.Healthy());
         return builder;
     }
 }

--- a/tests/ServiceDefaults.Tests/ServiceDefaults.Tests.csproj
+++ b/tests/ServiceDefaults.Tests/ServiceDefaults.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/ServiceDefaults.Tests/ServiceDefaultsExtensionsTests.cs
+++ b/tests/ServiceDefaults.Tests/ServiceDefaultsExtensionsTests.cs
@@ -1,0 +1,38 @@
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using ServiceDefaults;
+using Xunit;
+
+namespace ServiceDefaults.Tests;
+
+public class ServiceDefaultsExtensionsTests
+{
+    [Fact]
+    public void AddServiceDefaults_RegistersHealthChecks()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.AddServiceDefaults();
+
+        using var host = builder.Build();
+
+        var healthService = host.Services.GetRequiredService<HealthCheckService>();
+
+        Assert.NotNull(healthService);
+    }
+
+    [Fact]
+    public void AddServiceDefaults_RegistersHttpClientFactory()
+    {
+        var builder = Host.CreateApplicationBuilder();
+        builder.AddServiceDefaults();
+
+        using var host = builder.Build();
+
+        var factory = host.Services.GetRequiredService<IHttpClientFactory>();
+        var client = factory.CreateClient("resilient-test");
+
+        Assert.NotNull(client);
+    }
+}


### PR DESCRIPTION
## Summary
- wire up the AppHost project with .NET Aspire references and update the architecture notes to match the orchestrated topology
- centralize package version management, expand ServiceDefaults with telemetry/resilience wiring, and add default endpoint mappings in the web apps
- introduce an xUnit test project for ServiceDefaults and document the new solution/test workflow in the README

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e631b5d1e883289bb1796f15455aef