### PR TITLE
Fix AppHost references and add ECM minimal API

### DIFF
--- a/apps/apis/ecm/Program.cs
+++ b/apps/apis/ecm/Program.cs
@@ -4,11 +4,31 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
-builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
 app.MapDefaultEndpoints();
-app.MapControllers();
+
+app.MapGet("/api/ecm", () => Results.Ok(new { message = "ECM API placeholder" }))
+   .WithName("GetEcmStatus")
+   .WithDescription("Return a placeholder response for the ECM API.");
+
+app.MapPost("/api/ecm/documents", (DocumentCreateRequest request) =>
+{
+    var document = new DocumentSummary(Guid.NewGuid(), request.Name, DateTimeOffset.UtcNow);
+    return Results.Created($"/api/ecm/documents/{document.Id}", document);
+}).WithName("CreateDocument")
+  .WithDescription("Create a placeholder document and return a fake identifier.");
 
 app.Run();
+
+record DocumentCreateRequest(string Name);
+record DocumentSummary(Guid Id, string Name, DateTimeOffset CreatedAt);

--- a/host/AppHost/AppHost.csproj
+++ b/host/AppHost/AppHost.csproj
@@ -10,15 +10,15 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../libs/ServiceDefaults/ServiceDefaults.csproj" />
-    <ProjectReference Include="../../apps/ecm/Ecm.csproj" />
-    <ProjectReference Include="../../apps/document-services/DocumentServices.csproj" />
-    <ProjectReference Include="../../apps/file-services/FileServices.csproj" />
-    <ProjectReference Include="../../apps/workflow/Workflow.csproj" />
-    <ProjectReference Include="../../apps/search-api/SearchApi.csproj" />
-    <ProjectReference Include="../../apps/search-indexer/SearchIndexer.csproj" />
-    <ProjectReference Include="../../apps/outbox-dispatcher/OutboxDispatcher.csproj" />
-    <ProjectReference Include="../../apps/notify/Notify.csproj" />
-    <ProjectReference Include="../../apps/audit/Audit.csproj" />
-    <ProjectReference Include="../../apps/retention/Retention.csproj" />
+    <ProjectReference Include="../../apps/apis/ecm/Ecm.csproj" />
+    <ProjectReference Include="../../apps/apis/document-services/DocumentServices.csproj" />
+    <ProjectReference Include="../../apps/apis/file-services/FileServices.csproj" />
+    <ProjectReference Include="../../apps/workers/workflow/Workflow.csproj" />
+    <ProjectReference Include="../../apps/apis/search-api/SearchApi.csproj" />
+    <ProjectReference Include="../../apps/workers/search-indexer/SearchIndexer.csproj" />
+    <ProjectReference Include="../../apps/workers/outbox-dispatcher/OutboxDispatcher.csproj" />
+    <ProjectReference Include="../../apps/workers/notify/Notify.csproj" />
+    <ProjectReference Include="../../apps/workers/audit/Audit.csproj" />
+    <ProjectReference Include="../../apps/workers/retention/Retention.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- fix the AppHost project references so they point at the actual app locations
- add placeholder minimal API endpoints in the ECM service to allow exercising the host

## Testing
- not run (dotnet SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6372a7a688328a17b0475721d6f62