### PR TITLE
Fix Aspire AppHost configuration

### DIFF
--- a/host/AppHost/AppHost.csproj
+++ b/host/AppHost/AppHost.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.5.1" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>

--- a/host/AppHost/Program.cs
+++ b/host/AppHost/Program.cs
@@ -2,8 +2,6 @@ using Aspire.Hosting;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddDashboard("dashboard");
-
 var postgres = builder.AddConnectionString("postgres");
 var kafka = builder.AddConnectionString("kafka");
 var minio = builder.AddConnectionString("minio");


### PR DESCRIPTION
## Summary
- add the Aspire.AppHost SDK so generated project metadata becomes available
- remove the obsolete dashboard registration call that is no longer supported

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e640db7c1c83289eba1c64815e551d