### PR TITLE
Ensure Aspire launch settings use HTTPS endpoints

### DIFF
--- a/apps/apis/document-services/Properties/launchSettings.json
+++ b/apps/apis/document-services/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:63051;http://localhost:63054"
+      "applicationUrl": "https://localhost:63051"
     }
   }
 }

--- a/apps/apis/ecm/Properties/launchSettings.json
+++ b/apps/apis/ecm/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:63049;http://localhost:63058"
+      "applicationUrl": "https://localhost:63049"
     }
   }
 }

--- a/apps/apis/file-services/Properties/launchSettings.json
+++ b/apps/apis/file-services/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:63050;http://localhost:63056"
+      "applicationUrl": "https://localhost:63050"
     }
   }
 }

--- a/apps/apis/search-api/Properties/launchSettings.json
+++ b/apps/apis/search-api/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:63053;http://localhost:63055"
+      "applicationUrl": "https://localhost:63053"
     }
   }
 }

--- a/apps/workers/workflow/Properties/launchSettings.json
+++ b/apps/workers/workflow/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:63052;http://localhost:63057"
+      "applicationUrl": "https://localhost:63052"
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove HTTP endpoints from applicationUrl entries to satisfy Aspire secure transport validation

## Testing
- not run (dotnet not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68e64526a4508328a1f0b7721f4315c9