### PR TITLE
Set Aspire dashboard to allow unsecured transport by default

### DIFF
--- a/host/AppHost/Program.cs
+++ b/host/AppHost/Program.cs
@@ -1,5 +1,6 @@
 using Aspire.Hosting;
 using Microsoft.Extensions.Configuration;
+using System;
 using System.Collections.Generic;
 
 var builder = DistributedApplication.CreateBuilder(args);
@@ -9,6 +10,12 @@ var dashboardDefaults = new Dictionary<string, string?>();
 const string dashboardUrlVariable = "ASPNETCORE_URLS";
 const string dashboardGrpcVariable = "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL";
 const string dashboardHttpVariable = "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL";
+const string allowUnsecuredTransportVariable = "ASPIRE_ALLOW_UNSECURED_TRANSPORT";
+
+if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(allowUnsecuredTransportVariable)))
+{
+    Environment.SetEnvironmentVariable(allowUnsecuredTransportVariable, "true");
+}
 
 if (string.IsNullOrWhiteSpace(builder.Configuration[dashboardUrlVariable]))
 {


### PR DESCRIPTION
## Summary
- ensure the AppHost enables unsecured transport when no override is provided so the dashboard can listen on HTTP

## Testing
- not run (environment missing dotnet SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e64627afcc8328840cf4047394cc1e